### PR TITLE
feat: 신고 및 제재 도메인 엔티티 구현

### DIFF
--- a/backend/backend/src/main/java/com/shu/backend/domain/penalty/Penalty.java
+++ b/backend/backend/src/main/java/com/shu/backend/domain/penalty/Penalty.java
@@ -1,4 +1,33 @@
 package com.shu.backend.domain.penalty;
 
-public class Penalty {
+import com.shu.backend.domain.report.Report;
+import com.shu.backend.domain.report.enums.ReportReason;
+import com.shu.backend.domain.user.User;
+import com.shu.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class Penalty extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ReportReason reason;
+
+    private LocalDateTime expiresAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "report_id", nullable = false)
+    private Report report;
 }

--- a/backend/backend/src/main/java/com/shu/backend/domain/report/Report.java
+++ b/backend/backend/src/main/java/com/shu/backend/domain/report/Report.java
@@ -1,4 +1,59 @@
 package com.shu.backend.domain.report;
 
-public class Report {
+import com.shu.backend.domain.report.enums.ReportReason;
+import com.shu.backend.domain.report.enums.TargetType;
+import com.shu.backend.domain.user.User;
+import com.shu.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class Report extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reporter_id", nullable = false)
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reported_user_id", nullable = false)
+    private User reportedUser;
+
+    // 신고 대상 종류 (POST/COMMENT/CHAT)
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private TargetType targetType;
+
+    // 신고 대상 ID (postId, CommentId 등)
+    @Column(nullable = false)
+    private Long targetId;
+
+    // 신고 이유 (욕설, 선정적 내용, 광고 등)
+    @Enumerated(EnumType.STRING)
+    @Column(name = "report_reason", nullable = false)
+    private ReportReason reportReason;
+
+    // 처리 진행 상황
+    @Column(nullable = false)
+    private Boolean isProcessed = false;
+
+    // 처리 날짜
+    private LocalDateTime processedAt;
+
+    // 처리 함수
+    public void markProcessed() {
+        this.isProcessed = true;
+        this.processedAt = LocalDateTime.now();
+    }
+
+
+    //추후 Snapshot 도메인 및 Snapshot 필드 추가 예정
+
+
 }

--- a/backend/backend/src/main/java/com/shu/backend/domain/report/enums/ReportReason.java
+++ b/backend/backend/src/main/java/com/shu/backend/domain/report/enums/ReportReason.java
@@ -1,0 +1,10 @@
+package com.shu.backend.domain.report.enums;
+
+public enum ReportReason {
+    OBSCENE,
+    ABUSE,
+    SPAM,
+    ILLEGAL,
+    HARASSMENT,
+    ETC
+}

--- a/backend/backend/src/main/java/com/shu/backend/domain/report/enums/TargetType.java
+++ b/backend/backend/src/main/java/com/shu/backend/domain/report/enums/TargetType.java
@@ -1,0 +1,7 @@
+package com.shu.backend.domain.report.enums;
+
+public enum TargetType {
+    POST,
+    COMMENT,
+    USER
+}


### PR DESCRIPTION
- Report 엔티티 생성: 신고 유형, 신고자/피신고자, 스냅샷 필드 추후 추가 예정
- Penalty 엔티티 생성: 제재 종류, 시작/종료일, 상태값 추가
- User 연관관계 매핑 및 nullable 제약 설정

Resolves: #2